### PR TITLE
[CIRCLE-5062] Remove extra dex folder in usr/bin in resulting image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           name: Build dex binary
           command: |
             make release-binary
-            mkdir -p _output/bin/dex && cp /go/bin/dex _output/bin/dex
+            mkdir -p _output/bin && cp /go/bin/dex _output/bin
       - save_cache:
           key: v1-binary-{{ .Environment.CIRCLE_SHA1 }}
           paths:

--- a/scripts/circle-deploy
+++ b/scripts/circle-deploy
@@ -6,6 +6,11 @@ VERSION="0.1.${CIRCLE_BUILD_NUM}-${SHORT_SHA}"
 
 DOCKER_IMAGE=circleci/dex
 docker build -t $DOCKER_IMAGE .
+
+# quick sanity check to ensure image runs without error
+docker run $DOCKER_IMAGE
+
+# tag and deploy image to docker hub
 docker tag $DOCKER_IMAGE $DOCKER_IMAGE:$VERSION
 docker login -u $DOCKER_HUB_LOGIN -p $DOCKER_HUB_PASSWORD
 docker push $DOCKER_IMAGE


### PR DESCRIPTION
Fix a bug leading to an extra dex folder in location where the dex binary was supposed to live.

Also added a sanity check to ensure the image can run without error before deploying.